### PR TITLE
fedora-kinoite-testing: F43 rebase & cleanup

### DIFF
--- a/.github/workflows/fedora-kinoite-testing.yml
+++ b/.github/workflows/fedora-kinoite-testing.yml
@@ -1,25 +1,25 @@
-name: "Build Fedora Kinoite 42 image (testing)"
+name: "Build Fedora Kinoite 43 image (testing)"
 
 env:
   NAME: "fedora-kinoite"
   REGISTRY: "quay.io/travier"
-  BASEIMAGE: "quay.io/fedora-ostree-desktops/kinoite:42"
+  BASEIMAGE: "quay.io/fedora-ostree-desktops/kinoite:43"
 
 on:
-  # pull_request:
-  #   branches:
-  #     - main
-  #   paths:
-  #     - 'fedora-kinoite/**'
-  #     - '.github/workflows/fedora-kinoite-testing.yml'
-  # push:
-  #   branches:
-  #     - main
-  #   paths:
-  #     - 'fedora-kinoite/**'
-  #     - '.github/workflows/fedora-kinoite-testing.yml'
-  # schedule:
-  #   - cron: '0 4 * * *'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'fedora-kinoite/**'
+      - '.github/workflows/fedora-kinoite-testing.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'fedora-kinoite/**'
+      - '.github/workflows/fedora-kinoite-testing.yml'
+  schedule:
+    - cron: '0 4 * * *'
   workflow_dispatch:
     inputs:
       version:
@@ -94,53 +94,15 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
 
-      - name: Get kmod signing key
-        run: |
-          echo "${KMOD_KEY}" > key
-          echo "${KMOD_CERT}" | base64 --decode > cert
-        env:
-          KMOD_KEY: ${{ secrets.KMOD_KEY }}
-          KMOD_CERT: ${{ secrets.KMOD_CERT }}
-
       - name: Build container image
         uses: redhat-actions/buildah-build@v2
         with:
           image: ${{ env.NAME }}
-          tags: build.testing
+          tags: testing
           containerfiles: ${{ env.NAME }}/Containerfile.testing
           context: ${{ env.NAME }}
           layers: false
           oci: true
-          extra-args: |
-            --secret=id=key,src=key
-            --secret=id=cert,src=cert
-
-      - name: Rechunk container image
-        run: |
-          rpm-ostree experimental compose build-chunked-oci \
-            --bootc --format-version=1 \
-            --from localhost/${NAME}:build.testing \
-            --output containers-storage:localhost/${NAME}:rechunked.testing
-
-      - name: Write NOP Containerfile
-        run: |
-          echo "FROM localhost/${NAME}:rechunked.testing" > ${NAME}/Containerfile.testing.labels
-
-      - name: Add labels to container image
-        uses: redhat-actions/buildah-build@v2
-        with:
-          image: ${{ env.NAME }}
-          tags: testing
-          containerfiles: ${{ env.NAME }}/Containerfile.testing.labels
-          context: ${{ env.NAME }}
-          layers: false
-          oci: true
-          labels: |
-            org.opencontainers.image.version=${{ steps.version.outputs.version }}
-            org.opencontainers.image.title=Fedora Kinoite
-            org.opencontainers.image.description=Customized image of Fedora Kinoite
-            org.opencontainers.image.source=https://github.com/travier/fedora-kinoite
-            org.opencontainers.image.licenses=MIT
 
       - uses: sigstore/cosign-installer@v3.9.2
         if: (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
@@ -155,9 +117,9 @@ jobs:
           image: ${{ env.NAME }}
           registry: ${{ env.REGISTRY }}
           tags: testing
-          extra-args: |
-            --compression-format=zstd
-            --compression-level=19
+          # extra-args: |
+          #   --compression-format=zstd
+          #   --compression-level=19
 
       - name: Sign container image
         if: (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'

--- a/fedora-kinoite/Containerfile.testing
+++ b/fedora-kinoite/Containerfile.testing
@@ -1,31 +1,5 @@
 # Location not final and subject to change!
-FROM quay.io/fedora-ostree-desktops/kinoite:42 as builder
-
-# Build xpadneo kernel module
-RUN --mount=type=secret,id=key \
-    --mount=type=secret,id=cert \
-    <<EORUN
-set -xeuo pipefail
-curl --silent --location \
-    --output /etc/yum.repos.d/negativo17-fedora-multimedia.repo \
-    https://negativo17.org/repos/fedora-multimedia.repo
-ARCH="$(rpm -E '%_arch')"
-KERNEL="$(rpm -q "kernel" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
-RELEASE="$(rpm -E '%fedora')"
-dnf install -y akmods kernel-devel-matched-${KERNEL} akmod-xpadneo-*.fc${RELEASE}.${ARCH}
-mkdir -p /etc/pki/akmods/private/ /etc/pki/akmods/certs/
-cp /run/secrets/key /etc/pki/akmods/private/private_key.priv
-cp /run/secrets/cert /etc/pki/akmods/certs/public_key.der
-chmod 644 /etc/pki/akmods/private/private_key.priv /etc/pki/akmods/certs/public_key.der
-akmods --force --kernels "${KERNEL}" --kmod xpadneo
-modinfo /usr/lib/modules/${KERNEL}/extra/xpadneo/hid-xpadneo.ko.xz > /dev/null \
-    || (find /var/cache/akmods/xpadneo/ -name \*.log -print -exec cat {} \; && exit 1)
-rm -rf /etc/pki/akmods/private
-cp -a /usr/lib/modules/${KERNEL}/extra/ /extra
-EORUN
-
-# Location not final and subject to change!
-FROM quay.io/fedora-ostree-desktops/kinoite:42
+FROM quay.io/fedora-ostree-desktops/kinoite:43
 
 LABEL org.opencontainers.image.title="Fedora Kinoite"
 LABEL org.opencontainers.image.description="Customized image of Fedora Kinoite"
@@ -35,28 +9,11 @@ LABEL quay.expires-after=""
 
 # Copy custom config to /etc
 COPY etc etc
-COPY --from=builder /extra /usr/lib/modules/extra
 
-# - Setup xpadneo kernel module
-# - Replace noopenh264 with openh264
 # - Remove SetUID/SetGID bits
 RUN --mount=type=secret,id=cert \
     <<EORUN
 set -xeuo pipefail
-KERNEL="$(rpm -q "kernel" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
-mv /usr/lib/modules/extra /usr/lib/modules/${KERNEL}/extra
-depmod --all ${KERNEL}
-install -Dm644 /run/secrets/cert /etc/pki/akmods/certs/public_key.der
-curl --silent --location \
-    --output /etc/yum.repos.d/negativo17-fedora-multimedia.repo \
-    https://negativo17.org/repos/fedora-multimedia.repo
-dnf download xpadneo-kmod-common
-rpm --install --verbose --hash --noscript --nodeps ./xpadneo-kmod-common*.rpm
-rm ./xpadneo-kmod-common*.rpm
-sed -i 's/enabled=1/enabled=0/' /etc/yum.repos.d/negativo17-fedora-multimedia.repo
-dnf install -y openh264 mozilla-openh264
-sed -i 's/enabled=1/enabled=0/' /etc/yum.repos.d/fedora-cisco-openh264.repo
-dnf install -y steam-devices
 chmod ug-s \
     /usr/bin/chage \
     /usr/bin/chfn \
@@ -66,5 +23,5 @@ chmod ug-s \
     /usr/bin/passwd \
     /usr/bin/vmware-user-suid-wrapper
 dnf clean all
-ostree container commit
+bootc container lint
 EORUN


### PR DESCRIPTION
- Remove xpadneo module (connect via USB or use 8BitDo controller instead)
- Remove openh264 (consider switch to sysext)
- Remove steam-devices (consider switch to sysext)
- Remove rechunking
- Use compression from parent image (will be zstd for F43+)