### PR TITLE
fedora-kinoite/testing: Remove 'dnf clean all'

### DIFF
--- a/fedora-kinoite/Containerfile.testing
+++ b/fedora-kinoite/Containerfile.testing
@@ -22,6 +22,5 @@ chmod ug-s \
     /usr/bin/newgrp \
     /usr/bin/passwd \
     /usr/bin/vmware-user-suid-wrapper
-dnf clean all
 bootc container lint
 EORUN


### PR DESCRIPTION
No longer needed as we don't make any dnf calls.